### PR TITLE
fix: Downgrade protobuf version to 3.21.2 for finding symbol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-    		<version>4.0.0-rc-2</version>
+    		<version>3.21.2</version>
 		</dependency>
 	</dependencies>
 	<repositories>


### PR DESCRIPTION
I found the **4.0.0-rc2** version of _protobuf_ makes a problem related to the symbol missing (isStringEmpty method).
I assume [the commit 21d2228](https://github.com/JordanSamhi/JuCify/commit/21d2228f42553063bda22588643f7dd8a7321ec0) using the method.
I changed the version of _protobuf_ to **3.21.2** which still uses the method.

```
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< lu.uni.trux.jucify:JuCify >----------------------
[INFO] Building JuCify 0.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ JuCify ---
[INFO] Deleting /home/user/JuCify/target
[INFO] 
[INFO] ---------------------< lu.uni.trux.jucify:JuCify >----------------------
[INFO] Building JuCify 0.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-install-plugin:2.4:install-file (default-cli) @ JuCify ---
[INFO] Installing /home/user/JuCify/libs/soot-infoflow-android-classes.jar to /home/liberty/.m2/repository/de/tud/sse/soot-infoflow-android/2.7.1/soot-infoflow-android-2.7.1.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.172 s
[INFO] Finished at: 2022-07-19T21:57:23+09:00
[INFO] ------------------------------------------------------------------------
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< lu.uni.trux.jucify:JuCify >----------------------
[INFO] Building JuCify 0.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ JuCify ---
[INFO] 
[INFO] ---------------------< lu.uni.trux.jucify:JuCify >----------------------
[INFO] Building JuCify 0.1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-install-plugin:2.4:install-file (default-cli) @ JuCify ---
[INFO] Installing /home/user/JuCify/libs/soot-infoflow-classes.jar to /home/liberty/.m2/repository/de/tud/sse/soot-infoflow/2.7.1/soot-infoflow-2.7.1.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.165 s
[INFO] Finished at: 2022-07-19T21:57:24+09:00
[INFO] ------------------------------------------------------------------------
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< lu.uni.trux.jucify:JuCify >----------------------
[INFO] Building JuCify 0.1
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for de.upb.cs.swt:heros:jar:1.1.0-20190808.101407-2 is missing, no dependency information available
[WARNING] The POM for ca.mcgill.sable:jasmin:jar:3.0.1-20190408.112319-2 is missing, no dependency information available
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ JuCify ---
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ JuCify ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ JuCify ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 25 source files to /home/user/JuCify/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[14571,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[14583,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[26453,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[26465,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[31893,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[31905,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[34782,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[34794,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[35350,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[35362,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[37512,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[37524,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[39745,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[39757,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[92957,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[92978,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[99269,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[99290,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[102297,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[102318,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[103474,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[103495,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[107123,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[107144,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[108300,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[108321,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[117490,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[117511,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[119491,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[119512,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[121460,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[121481,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[122505,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[122526,50] cannot find symbol
  symbol:   method isStringEmpty(java.lang.Object)
  location: class com.google.protobuf.GeneratedMessageV3
[INFO] 34 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.383 s
[INFO] Finished at: 2022-07-19T21:57:26+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project JuCify: Compilation failure: Compilation failure: 
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[14571,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[14583,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[26453,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[26465,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[31893,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[31905,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[34782,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[34794,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[35350,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[35362,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[37512,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[37524,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[39745,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[39757,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[92957,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[92978,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[99269,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[99290,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[102297,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[102318,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[103474,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[103495,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[107123,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[107144,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[108300,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[108321,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[117490,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[117511,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[119491,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[119512,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[121460,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[121481,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[122505,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] /home/user/JuCify/src/main/java/lu/uni/trux/jucify/callgraph/Ast.java:[122526,50] cannot find symbol
[ERROR]   symbol:   method isStringEmpty(java.lang.Object)
[ERROR]   location: class com.google.protobuf.GeneratedMessageV3
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

